### PR TITLE
Revoke shared ownership for painters

### DIFF
--- a/source/examples/viewer-glfw/main.cpp
+++ b/source/examples/viewer-glfw/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char * argv[])
     // Choose a painter
     std::string name = (argc > 1) ? argv[1] : "CubeScape";
 
-    gloperate::Painter * painter = nullptr;
+    std::unique_ptr<gloperate::Painter> painter(nullptr);
     Plugin * plugin = pluginManager.plugin(name);
 
     if (!plugin) 
@@ -49,12 +49,12 @@ int main(int argc, char * argv[])
         return 1;
     }
 
-    painter = plugin->createPainter(resourceManager);
+    painter.reset(plugin->createPainter(resourceManager));
 
     Window::init();
 
     Window window(resourceManager);
-    window.setPainter(painter);
+    window.setPainter(painter.get());
     window.setEventHandler(new WindowEventHandler());
 
     ContextFormat format;

--- a/source/examples/viewer-qt/main.cpp
+++ b/source/examples/viewer-qt/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char * argv[])
     // Choose a painter
     std::string name = (argc > 1) ? argv[1] : "CubeScape";
 
-    gloperate::Painter * painter = nullptr;
+    std::unique_ptr<gloperate::Painter> painter(nullptr);
     Plugin * plugin = pluginManager.plugin(name);
 
     if (!plugin)
@@ -64,7 +64,7 @@ int main(int argc, char * argv[])
         return 1;
     }
 
-    painter = plugin->createPainter(resourceManager);
+    painter.reset(plugin->createPainter(resourceManager));
 
     // Create Event Provider
     QtKeyEventProvider * keyProvider = new QtKeyEventProvider();
@@ -79,14 +79,14 @@ int main(int argc, char * argv[])
     format.setDepthBufferSize(24);
 
     QtOpenGLWindow * window = new QtOpenGLWindow(resourceManager, format);
-    window->setPainter(painter);
+    window->setPainter(painter.get());
     window->installEventFilter(keyProvider);
     window->installEventFilter(mouseProvider);
     window->installEventFilter(wheelProvider);
     
     // Create Mapping
     QtViewerMapping * mapping = new QtViewerMapping(window);
-    mapping->setPainter(painter);
+    mapping->setPainter(painter.get());
     mapping->addProvider(keyProvider);
     mapping->addProvider(mouseProvider);
     mapping->addProvider(wheelProvider);

--- a/source/gloperate-glfw/include/gloperate-glfw/Window.h
+++ b/source/gloperate-glfw/include/gloperate-glfw/Window.h
@@ -159,7 +159,7 @@ protected:
 
     Mode m_mode;
 
-    globjects::ref_ptr<gloperate::Painter> m_painter;
+    gloperate::Painter * m_painter;
     gloperate::ResourceManager & m_resourceManager;
 
 private:

--- a/source/gloperate-glfw/source/Window.cpp
+++ b/source/gloperate-glfw/source/Window.cpp
@@ -43,6 +43,7 @@ Window::Window(gloperate::ResourceManager & resourceManager)
 ,   m_window(nullptr)
 ,   m_quitOnDestroy(true)
 ,   m_mode(WindowMode)
+,   m_painter(nullptr)
 ,   m_resourceManager(resourceManager)
 {
     s_instances.insert(this);

--- a/source/gloperate-qt/include/gloperate-qt/QtOpenGLWindow.h
+++ b/source/gloperate-qt/include/gloperate-qt/QtOpenGLWindow.h
@@ -86,7 +86,7 @@ protected:
 
 protected:
     gloperate::ResourceManager & m_resourceManager;
-    globjects::ref_ptr<gloperate::Painter> m_painter;          /**< Currently used painter */
+    gloperate::Painter * m_painter;          /**< Currently used painter */
     QScopedPointer<TimePropagator>         m_timePropagator;  /**< Time propagator for continous updates */
 
 

--- a/source/gloperate-qt/source/QtOpenGLWindow.cpp
+++ b/source/gloperate-qt/source/QtOpenGLWindow.cpp
@@ -83,17 +83,7 @@ void QtOpenGLWindow::setPainter(Painter * painter)
         m_timePropagator.reset(new TimePropagator(this, m_painter->getCapability<gloperate::AbstractVirtualTimeCapability>()));
     }
 
-
-    if (m_initialized)
-    {
-        AbstractViewportCapability * viewportCapability = m_painter->getCapability<AbstractViewportCapability>();
-
-        if (viewportCapability)
-        {
-            // Resize painter
-            viewportCapability->setViewport(0, 0, width(), height());
-        }
-    }
+    m_initialized = false;
 }
 
 void QtOpenGLWindow::onInitialize()

--- a/source/gloperate-qt/source/QtOpenGLWindow.cpp
+++ b/source/gloperate-qt/source/QtOpenGLWindow.cpp
@@ -28,6 +28,7 @@ namespace gloperate_qt
 QtOpenGLWindow::QtOpenGLWindow(gloperate::ResourceManager & resourceManager)
 : QtOpenGLWindowBase()
 , m_resourceManager(resourceManager)
+, m_painter(nullptr)
 , m_timePropagator(nullptr)
 {
 }
@@ -39,6 +40,7 @@ QtOpenGLWindow::QtOpenGLWindow(gloperate::ResourceManager & resourceManager)
 QtOpenGLWindow::QtOpenGLWindow(gloperate::ResourceManager & resourceManager, const QSurfaceFormat & format)
 : QtOpenGLWindowBase(format)
 , m_resourceManager(resourceManager)
+, m_painter(nullptr)
 , m_timePropagator(nullptr)
 {
 }

--- a/source/gloperate/include/gloperate/painter/Painter.h
+++ b/source/gloperate/include/gloperate/painter/Painter.h
@@ -4,8 +4,6 @@
 
 #include <gloperate/gloperate_api.h>
 
-#include <globjects/base/Referenced.h>
-
 #include <gloperate/painter/AbstractCapability.h>
 
 
@@ -31,7 +29,7 @@ class ResourceManager;
 *    use capabilities to describe what kind of functionality and interfaces
 *    it supports. See AbstractCapability for more information on capabilities.
 */
-class GLOPERATE_API Painter : public globjects::Referenced
+class GLOPERATE_API Painter
 {
 public:
     /**


### PR DESCRIPTION
Use strong ownership when dealing with painters, especially the windows have a ```unique_ptr``` for holding the painters they should manage.
This is a adaption for https://github.com/hpicgs/globjects/issues/276.