### PR TITLE
Treat symlinks as files

### DIFF
--- a/source/gloperate/source/base/DirectoryIterator.cpp
+++ b/source/gloperate/source/base/DirectoryIterator.cpp
@@ -66,7 +66,7 @@ void DirectoryIterator::files(
         const std::string p = path + g_sep + name;
 
         bool isDir  = entry->d_type == DT_DIR;
-        bool isFile = entry->d_type == DT_REG;
+        bool isFile = entry->d_type == DT_REG || entry->d_type == DT_LNK;
 
         if (entry->d_type == DT_UNKNOWN)
         {

--- a/source/gloperate/source/base/dirent_msvc.h
+++ b/source/gloperate/source/base/dirent_msvc.h
@@ -188,6 +188,7 @@
 #define DT_SOCK     S_IFSOCK
 #define DT_CHR      S_IFCHR
 #define DT_BLK      S_IFBLK
+#define DT_LNK		S_IFLNK
 
 /* Macros for converting between st_mode and d_type */
 #define IFTODT(mode) ((mode) & S_IFMT)


### PR DESCRIPTION
For development it may be useful to treat symlinks to dynamic libraries as valid plugins.
Probably the provided implementation is not that gracious, improvements or other opinions are welcome.