### PR TITLE
Add iostream include in CubeScape example

### DIFF
--- a/source/examples/globjects-painters/cubescape/CubeScape.cpp
+++ b/source/examples/globjects-painters/cubescape/CubeScape.cpp
@@ -1,6 +1,7 @@
 #include "CubeScape.h"
 
 #include <array>
+#include <iostream>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>


### PR DESCRIPTION
There is a build error without the include for me.