### PR TITLE
Refactor, fix, and improve

### DIFF
--- a/source/examples/globjects-painters/cubescape/CubeScape.cpp
+++ b/source/examples/globjects-painters/cubescape/CubeScape.cpp
@@ -35,7 +35,7 @@ using namespace globjects;
 using gloperate::make_unique;
 
 CubeScape::CubeScape(gloperate::ResourceManager & resourceManager)
-:   Painter{resourceManager}
+:   Painter(resourceManager)
 ,   m_numCubes{25}
 ,   m_animation{true}
 ,   a_vertex{-1}

--- a/source/examples/globjects-painters/cubescape/CubeScape.cpp
+++ b/source/examples/globjects-painters/cubescape/CubeScape.cpp
@@ -18,6 +18,7 @@
 #include <gloperate/resources/RawFile.h>
 
 #include <gloperate/base/RenderTargetType.h>
+#include <gloperate/base/make_unique.hpp>
 
 #include <gloperate/painter/Camera.h>
 #include <gloperate/painter/TargetFramebufferCapability.h>
@@ -31,31 +32,27 @@ using namespace gl;
 using namespace glm;
 using namespace globjects;
 
+using gloperate::make_unique;
+
 CubeScape::CubeScape(gloperate::ResourceManager & resourceManager)
-: Painter(resourceManager)
-, m_numCubes(25)
-, m_animation(true)
-, m_targetFramebufferCapability(new gloperate::TargetFramebufferCapability)
-, m_viewportCapability(new gloperate::ViewportCapability)
-, m_projectionCapability(new gloperate::PerspectiveProjectionCapability(m_viewportCapability))
-, m_typedRenderTargetCapability(new gloperate::TypedRenderTargetCapability())
-, m_cameraCapability(new gloperate::CameraCapability())
-, m_timeCapability(new gloperate::VirtualTimeCapability)
-, a_vertex(-1)
-, u_transform(-1)
-, u_time(-1)
-, u_numcubes(-1)
+:   Painter{resourceManager}
+,   m_numCubes{25}
+,   m_animation{true}
+,   a_vertex{-1}
+,   u_transform{-1}
+,   u_time{-1}
+,   u_numcubes{-1}
 {
+    m_targetFramebufferCapability = addCapability(make_unique<gloperate::TargetFramebufferCapability>());
+    m_viewportCapability = addCapability(make_unique<gloperate::ViewportCapability>());
+    m_projectionCapability = addCapability(make_unique<gloperate::PerspectiveProjectionCapability>(m_viewportCapability));
+    m_typedRenderTargetCapability = addCapability(make_unique<gloperate::TypedRenderTargetCapability>());
+    m_cameraCapability = addCapability(make_unique<gloperate::CameraCapability>());
+    m_timeCapability = addCapability(make_unique<gloperate::VirtualTimeCapability>());
+    
     m_timeCapability->setLoopDuration(20.0f * pi<float>());
 
     m_targetFramebufferCapability->changed.connect([this](){ this->onTargetFramebufferChanged();});
-    
-    addCapability(m_targetFramebufferCapability);
-    addCapability(m_viewportCapability);
-    addCapability(m_projectionCapability);
-    addCapability(m_cameraCapability);
-    addCapability(m_timeCapability);
-    addCapability(m_typedRenderTargetCapability);
 }
 
 CubeScape::~CubeScape()

--- a/source/examples/globjects-painters/rotating-quad/RotatingQuad.cpp
+++ b/source/examples/globjects-painters/rotating-quad/RotatingQuad.cpp
@@ -13,6 +13,7 @@
 #include <globjects/VertexArray.h>
 #include <globjects/VertexAttributeBinding.h>
 
+#include <gloperate/base/make_unique.hpp>
 #include <gloperate/resources/ResourceManager.h>
 #include <gloperate/painter/ViewportCapability.h>
 #include <gloperate/painter/VirtualTimeCapability.h>
@@ -22,6 +23,7 @@ using namespace globjects;
 using namespace gloperate;
 using namespace gl;
 
+using gloperate::make_unique;
 
 static const char * s_vertexShader = R"(
 #version 140
@@ -64,8 +66,8 @@ RotatingQuad::RotatingQuad(ResourceManager & resourceManager)
 {
     m_timeCapability->setLoopDuration(2.0f * glm::pi<float>());
 
-    addCapability(m_viewportCapability);
-    addCapability(m_timeCapability);
+    m_viewportCapability = addCapability(make_unique<gloperate::ViewportCapability>());
+    m_timeCapability = addCapability(make_unique<gloperate::VirtualTimeCapability>());
 }
 
 RotatingQuad::~RotatingQuad()

--- a/source/examples/globjects-painters/textured-quad/TexturedQuad.cpp
+++ b/source/examples/globjects-painters/textured-quad/TexturedQuad.cpp
@@ -5,6 +5,7 @@
 #include <glbinding/gl/gl.h>
 #include <globjects/logging.h>
 
+#include <gloperate/base/make_unique.hpp>
 #include <gloperate/painter/ViewportCapability.h>
 
 
@@ -12,12 +13,13 @@ using namespace gloperate;
 using namespace globjects;
 using namespace gl;
 
+using gloperate::make_unique;
 
 TexturedQuad::TexturedQuad(ResourceManager & resourceManager)
 : Painter(resourceManager)
 , m_viewportCapability(new gloperate::ViewportCapability)
 {
-    addCapability(m_viewportCapability);
+    m_viewportCapability = addCapability(make_unique<gloperate::ViewportCapability>());
 }
 
 TexturedQuad::~TexturedQuad()

--- a/source/examples/globjects-painters/textured-quad/TexturedQuad.h
+++ b/source/examples/globjects-painters/textured-quad/TexturedQuad.h
@@ -16,22 +16,17 @@ class AbstractViewportCapability;
 
 class TexturedQuad : public gloperate::Painter
 {
-
-
 public:
     TexturedQuad(gloperate::ResourceManager & resourceManager);
     virtual ~TexturedQuad();
-
 
 protected:
     virtual void onInitialize();
     virtual void onPaint();
 
-
 protected:
     void createAndSetupTexture();
     void createAndSetupGeometry();
-
 
 protected:
     /* capabilities */
@@ -39,6 +34,4 @@ protected:
 
     globjects::ref_ptr<globjects::Texture>           m_texture;
     globjects::ref_ptr<gloperate::ScreenAlignedQuad> m_quad;
-
-
 };

--- a/source/examples/pipeline-painters/CMakeLists.txt
+++ b/source/examples/pipeline-painters/CMakeLists.txt
@@ -70,7 +70,7 @@ source_group_by_path(${source_path} "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.hpp$"
 
 # Build library
 
-add_library(${target} SHARED ${api_includes} ${sources})
+add_library(${target} SHARED ${headers} ${sources})
 
 target_link_libraries(${target} ${libs})
 

--- a/source/examples/pipeline-painters/postprocessing/Postprocessing.cpp
+++ b/source/examples/pipeline-painters/postprocessing/Postprocessing.cpp
@@ -1,24 +1,42 @@
 
 #include "Postprocessing.h"
 
-#include <gloperate/painter/AbstractTargetFramebufferCapability.h>
-#include <gloperate/painter/AbstractViewportCapability.h>
-#include <gloperate/painter/AbstractVirtualTimeCapability.h>
-#include <gloperate/painter/AbstractCameraCapability.h>
-#include <gloperate/painter/AbstractProjectionCapability.h>
-#include <gloperate/painter/AbstractTypedRenderTargetCapability.h>
+#include <glm/gtc/constants.hpp>
+
+#include <gloperate/base/make_unique.hpp>
+#include <gloperate/painter/ViewportCapability.h>
+#include <gloperate/painter/VirtualTimeCapability.h>
+#include <gloperate/painter/TargetFramebufferCapability.h>
+#include <gloperate/painter/CameraCapability.h>
+#include <gloperate/painter/PerspectiveProjectionCapability.h>
+#include <gloperate/painter/TypedRenderTargetCapability.h>
+
+
+using gloperate::make_unique;
 
 Postprocessing::Postprocessing(gloperate::ResourceManager & resourceManager)
-: PipelinePainter(resourceManager, m_pipeline)
+:   PipelinePainter(resourceManager, m_pipeline)
 {
-    addCapability(m_pipeline.targetFramebufferCapability());
-    addCapability(m_pipeline.viewportCapability());
-    addCapability(m_pipeline.virtualTimeCapability());
-    addCapability(m_pipeline.cameraCapability());
-    addCapability(m_pipeline.projectionCapability());
-    addCapability(m_pipeline.renderTargetCapability());
-}
+    auto targetFBO = addCapability(make_unique<gloperate::TargetFramebufferCapability>());
+    auto viewport = addCapability(make_unique<gloperate::ViewportCapability>());
+    auto time = addCapability(make_unique<gloperate::VirtualTimeCapability>());
+    auto camera = addCapability(make_unique<gloperate::CameraCapability>());
+    auto projection = addCapability(make_unique<gloperate::PerspectiveProjectionCapability>(viewport));
+    auto renderTargets = addCapability(make_unique<gloperate::TypedRenderTargetCapability>());
 
-Postprocessing::~Postprocessing()
-{
+    m_pipeline.targetFBO.setData(targetFBO);
+    m_pipeline.viewport.setData(viewport);
+    m_pipeline.time.setData(time);
+    m_pipeline.camera.setData(camera);
+    m_pipeline.projection.setData(projection);
+    m_pipeline.renderTargets.setData(renderTargets);
+
+    targetFBO->changed.connect([this]() { m_pipeline.targetFBO.invalidate(); });
+    viewport->changed.connect([this]() { m_pipeline.viewport.invalidate(); });
+    time->changed.connect([this]() { m_pipeline.time.invalidate(); });
+    
+    projection->setZNear(0.1f);
+    projection->setZFar(16.f);
+    
+    time->setLoopDuration(glm::pi<float>() * 2);
 }

--- a/source/examples/pipeline-painters/postprocessing/Postprocessing.h
+++ b/source/examples/pipeline-painters/postprocessing/Postprocessing.h
@@ -9,7 +9,6 @@ class Postprocessing : public gloperate::PipelinePainter
 {
 public:
     Postprocessing(gloperate::ResourceManager & resourceManager);
-    virtual ~Postprocessing();
 
 protected:
     PostprocessingPipeline m_pipeline;

--- a/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.cpp
+++ b/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.cpp
@@ -30,10 +30,8 @@
 #include <gloperate/painter/AbstractViewportCapability.h>
 #include <gloperate/painter/AbstractVirtualTimeCapability.h>
 #include <gloperate/painter/AbstractTargetFramebufferCapability.h>
-#include <gloperate/painter/ViewportCapability.h>
-#include <gloperate/painter/VirtualTimeCapability.h>
-#include <gloperate/painter/TargetFramebufferCapability.h>
-#include <gloperate/painter/CameraCapability.h>
+#include <gloperate/painter/AbstractProjectionCapability.h>
+#include <gloperate/painter/AbstractCameraCapability.h>
 #include <gloperate/painter/PerspectiveProjectionCapability.h>
 #include <gloperate/painter/TypedRenderTargetCapability.h>
 
@@ -225,45 +223,22 @@ protected:
 PostprocessingPipeline::PostprocessingPipeline()
 : m_rasterization(new RasterizationStage)
 , m_postprocessing(new PostprocessingStage)
-, m_targetFBO(new gloperate::TargetFramebufferCapability)
-, m_viewport(new gloperate::ViewportCapability)
-, m_time(new gloperate::VirtualTimeCapability)
-, m_camera(new gloperate::CameraCapability)
-, m_projection(new gloperate::PerspectiveProjectionCapability(m_viewport))
-, m_renderTargets(new gloperate::TypedRenderTargetCapability)
 {
-    m_targetFBO.data()->changed.connect([this]() {
-        m_targetFBO.invalidate();
-    });
-    m_viewport.data()->changed.connect([this]() {
-        m_viewport.invalidate();
-    });
-    m_time.data()->changed.connect([this]() {
-        m_time.invalidate();
-    });
-
-    auto projection = dynamic_cast<gloperate::PerspectiveProjectionCapability*>(m_projection.data());
-
-    assert(projection != nullptr);
-
-    projection->setZNear(0.1f);
-    projection->setZFar(16.f);
-
-    m_time.data()->setLoopDuration(glm::pi<float>() * 2);
-
-    m_rasterization->camera = m_camera;
-    m_rasterization->viewport = m_viewport;
-    m_rasterization->time = m_time;
-    m_rasterization->projection = m_projection;
+    m_rasterization->camera = camera;
+    m_rasterization->viewport = viewport;
+    m_rasterization->time = time;
+    m_rasterization->projection = projection;
 
     m_postprocessing->color = m_rasterization->color;
     m_postprocessing->normal = m_rasterization->normal;
     m_postprocessing->geometry = m_rasterization->geometry;
-    m_postprocessing->targetFramebuffer = m_targetFBO;
+    m_postprocessing->targetFramebuffer = targetFBO;
 
-    m_rasterization->color.invalidated.connect([this]() {
-        dynamic_cast<gloperate::TypedRenderTargetCapability*>(m_renderTargets.data())->setRenderTarget(gloperate::RenderTargetType::Depth, m_rasterization->fbo(), gl::GLenum::GL_DEPTH_ATTACHMENT, gl::GLenum::GL_DEPTH_COMPONENT);
-    });
+    m_rasterization->color.invalidated.connect(
+        [this]()
+        {
+            dynamic_cast<gloperate::TypedRenderTargetCapability *>(renderTargets.data())->setRenderTarget(gloperate::RenderTargetType::Depth, m_rasterization->fbo(), gl::GLenum::GL_DEPTH_ATTACHMENT, gl::GLenum::GL_DEPTH_COMPONENT);
+        });
 
     addStages(
         m_rasterization,
@@ -273,34 +248,4 @@ PostprocessingPipeline::PostprocessingPipeline()
 
 PostprocessingPipeline::~PostprocessingPipeline()
 {
-}
-
-gloperate::AbstractTargetFramebufferCapability * PostprocessingPipeline::targetFramebufferCapability()
-{
-    return m_targetFBO;
-}
-
-gloperate::AbstractViewportCapability * PostprocessingPipeline::viewportCapability()
-{
-    return m_viewport;
-}
-
-gloperate::AbstractVirtualTimeCapability * PostprocessingPipeline::virtualTimeCapability()
-{
-    return m_time;
-}
-
-gloperate::AbstractCameraCapability * PostprocessingPipeline::cameraCapability()
-{
-    return m_camera;
-}
-
-gloperate::AbstractProjectionCapability * PostprocessingPipeline::projectionCapability()
-{
-    return m_projection;
-}
-
-gloperate::AbstractTypedRenderTargetCapability * PostprocessingPipeline::renderTargetCapability()
-{
-    return m_renderTargets;
 }

--- a/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.cpp
+++ b/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.cpp
@@ -224,8 +224,6 @@ protected:
 };
 
 PostprocessingPipeline::PostprocessingPipeline()
-:   m_rasterization(new RasterizationStage)
-,   m_postprocessing(new PostprocessingStage)
 {
     auto rasterizationStage = make_unique<RasterizationStage>();
     auto postprocessingStage = make_unique<PostprocessingStage>();
@@ -235,15 +233,15 @@ PostprocessingPipeline::PostprocessingPipeline()
     rasterizationStage->time = time;
     rasterizationStage->projection = projection;
 
-    postprocessingStage->color = m_rasterization->color;
-    postprocessingStage->normal = m_rasterization->normal;
-    postprocessingStage->geometry = m_rasterization->geometry;
+    postprocessingStage->color = rasterizationStage->color;
+    postprocessingStage->normal = rasterizationStage->normal;
+    postprocessingStage->geometry = rasterizationStage->geometry;
     postprocessingStage->targetFramebuffer = targetFBO;
 
     rasterizationStage->color.invalidated.connect(
-        [this]()
+        [this, &rasterizationStage]()
         {
-            dynamic_cast<gloperate::TypedRenderTargetCapability *>(renderTargets.data())->setRenderTarget(gloperate::RenderTargetType::Depth, m_rasterization->fbo(), gl::GLenum::GL_DEPTH_ATTACHMENT, gl::GLenum::GL_DEPTH_COMPONENT);
+            dynamic_cast<gloperate::TypedRenderTargetCapability *>(renderTargets.data())->setRenderTarget(gloperate::RenderTargetType::Depth, rasterizationStage->fbo(), gl::GLenum::GL_DEPTH_ATTACHMENT, gl::GLenum::GL_DEPTH_COMPONENT);
         });
 
     addStages(

--- a/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.h
+++ b/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.h
@@ -23,22 +23,15 @@ class PostprocessingPipeline : public gloperate::AbstractPipeline
 public:
     PostprocessingPipeline();
     virtual ~PostprocessingPipeline();
-
-    gloperate::AbstractTargetFramebufferCapability * targetFramebufferCapability();
-    gloperate::AbstractViewportCapability * viewportCapability();
-    gloperate::AbstractVirtualTimeCapability * virtualTimeCapability();
-    gloperate::AbstractCameraCapability * cameraCapability();
-    gloperate::AbstractProjectionCapability * projectionCapability();
-    gloperate::AbstractTypedRenderTargetCapability * renderTargetCapability();
+    
+    gloperate::Data<gloperate::AbstractTargetFramebufferCapability *> targetFBO;
+    gloperate::Data<gloperate::AbstractViewportCapability *> viewport;
+    gloperate::Data<gloperate::AbstractVirtualTimeCapability *> time;
+    gloperate::Data<gloperate::AbstractCameraCapability *> camera;
+    gloperate::Data<gloperate::AbstractProjectionCapability *> projection;
+    gloperate::Data<gloperate::AbstractTypedRenderTargetCapability *> renderTargets;
 
 protected:
     RasterizationStage  * m_rasterization;
     PostprocessingStage * m_postprocessing;
-
-    gloperate::Data<gloperate::AbstractTargetFramebufferCapability *> m_targetFBO;
-    gloperate::Data<gloperate::AbstractViewportCapability *> m_viewport;
-    gloperate::Data<gloperate::AbstractVirtualTimeCapability *> m_time;
-    gloperate::Data<gloperate::AbstractCameraCapability *> m_camera;
-    gloperate::Data<gloperate::AbstractProjectionCapability *> m_projection;
-    gloperate::Data<gloperate::AbstractTypedRenderTargetCapability *> m_renderTargets;
 };

--- a/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.h
+++ b/source/examples/pipeline-painters/postprocessing/PostprocessingPipeline.h
@@ -30,8 +30,4 @@ public:
     gloperate::Data<gloperate::AbstractCameraCapability *> camera;
     gloperate::Data<gloperate::AbstractProjectionCapability *> projection;
     gloperate::Data<gloperate::AbstractTypedRenderTargetCapability *> renderTargets;
-
-protected:
-    RasterizationStage  * m_rasterization;
-    PostprocessingStage * m_postprocessing;
 };

--- a/source/examples/viewer-qt/QtViewerMapping.cpp
+++ b/source/examples/viewer-qt/QtViewerMapping.cpp
@@ -1,10 +1,9 @@
 #include "QtViewerMapping.h"
 
-#include <widgetzeug/make_unique.hpp>
-
 #include <glbinding/gl/enum.h>
 
 #include <gloperate/base/RenderTargetType.h>
+#include <gloperate/base/make_unique.hpp>
 #include <gloperate/painter/Camera.h>
 #include <gloperate/painter/AbstractCameraCapability.h>
 #include <gloperate/painter/AbstractProjectionCapability.h>
@@ -25,7 +24,7 @@
 using namespace gloperate;
 using namespace gloperate_qt;
 
-using widgetzeug::make_unique;
+using gloperate::make_unique;
 
 QtViewerMapping::QtViewerMapping(QtOpenGLWindow * window)
 :   AbstractQtMapping(window)

--- a/source/examples/viewer-qt/QtViewerMapping.h
+++ b/source/examples/viewer-qt/QtViewerMapping.h
@@ -15,6 +15,9 @@ namespace gloperate
     class CoordinateProvider;
     class TypedRenderTargetCapability;
     class WorldInHandNavigation;
+    class KeyboardEvent;
+    class MouseEvent;
+    class WheelEvent;
 }
 
 class QtViewerMapping : public gloperate_qt::AbstractQtMapping
@@ -27,6 +30,10 @@ public:
 
 protected:
     virtual void mapEvent(gloperate::AbstractEvent * event) override;
+
+    void mapKeyboardEvent(gloperate::KeyboardEvent * event);
+    void mapMouseEvent(gloperate::MouseEvent * event);
+    void mapWheelEvent(gloperate::WheelEvent * event);
 
     void onTargetFramebufferChanged();
 

--- a/source/examples/viewer-qt/QtViewerMapping.h
+++ b/source/examples/viewer-qt/QtViewerMapping.h
@@ -4,8 +4,16 @@
 
 #include <memory>
 
-namespace gloperate {
+
+namespace globjects
+{ 
+    class Framebuffer;
+}
+
+namespace gloperate
+{
     class CoordinateProvider;
+    class TypedRenderTargetCapability;
     class WorldInHandNavigation;
 }
 
@@ -20,7 +28,10 @@ public:
 protected:
     virtual void mapEvent(gloperate::AbstractEvent * event) override;
 
+    void onTargetFramebufferChanged();
+
 protected:
     std::unique_ptr<gloperate::WorldInHandNavigation> m_navigation;
     std::unique_ptr<gloperate::CoordinateProvider> m_coordProvider;
+    std::unique_ptr<gloperate::TypedRenderTargetCapability> m_renderTarget;
 };

--- a/source/examples/viewer-qt/main.cpp
+++ b/source/examples/viewer-qt/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char * argv[])
     pluginManager.scan("painters");
 
     // Choose a painter
-    std::string name = (argc > 1) ? argv[1] : "CubeScape";
+    std::string name = (argc > 1) ? argv[1] : "PostprocessingPipeline";
 
     std::unique_ptr<gloperate::Painter> painter(nullptr);
     Plugin * plugin = pluginManager.plugin(name);

--- a/source/gloperate-qt/include/gloperate-qt/QtOpenGLWindow.h
+++ b/source/gloperate-qt/include/gloperate-qt/QtOpenGLWindow.h
@@ -1,7 +1,7 @@
 #pragma once
 
 
-#include <QScopedPointer>
+#include <memory>
 
 #include <globjects/base/ref_ptr.h>
 
@@ -86,10 +86,9 @@ protected:
 
 protected:
     gloperate::ResourceManager & m_resourceManager;
-    gloperate::Painter * m_painter;          /**< Currently used painter */
-    QScopedPointer<TimePropagator>         m_timePropagator;  /**< Time propagator for continous updates */
-
-
+    gloperate::Painter * m_painter;                    /**< Currently used painter */
+    std::unique_ptr<TimePropagator> m_timePropagator;  /**< Time propagator for continous updates */
+    
 };
 
 

--- a/source/gloperate-qt/include/gloperate-qt/TimePropagator.h
+++ b/source/gloperate-qt/include/gloperate-qt/TimePropagator.h
@@ -20,10 +20,10 @@ namespace gloperate_qt
 
 /**
 *  @brief
-*    Tool class to propagate continues time updates to a window
+*    Tool class to propagate continuous time updates to a window
 *
 *  @remarks
-*    This class is used in a window to allow for continues updates (e.g., to
+*    This class is used in a window to allow for continuous updates (e.g., to
 *    implement animations). It take a VirtualTimeCapability of a painter to
 *    propagate the time change to the painter, and automatically triggers
 *    an update of the window containing the painter.
@@ -42,7 +42,9 @@ public:
     *  @param[in] capability
     *    VirtualTimeCapability that is informed about the time change
     */
-    TimePropagator(gloperate_qt::QtOpenGLWindowBase * window, gloperate::AbstractVirtualTimeCapability * capability);
+    TimePropagator(gloperate_qt::QtOpenGLWindowBase * window);
+    
+    void setCapability(gloperate::AbstractVirtualTimeCapability * capability);
 
 protected slots:
     /**
@@ -52,10 +54,10 @@ protected slots:
     void update();
 
 protected:
-    gloperate_qt::QtOpenGLWindowBase          * m_window;        /**< Window that is updated when the timer has elapsed */
-    gloperate::AbstractVirtualTimeCapability * m_capability;    /**< VirtualTimeCapability that is informed about the time change */
-    QScopedPointer<QTimer>                           m_timer;            /**< Qt timer for continues updates */
-    gloperate::ChronoTimer                           m_time;            /**< Time measurement */
+    gloperate_qt::QtOpenGLWindowBase         * m_window;     /**< Window that is updated when the timer has elapsed */
+    gloperate::AbstractVirtualTimeCapability * m_capability; /**< VirtualTimeCapability that is informed about the time change */
+    QScopedPointer<QTimer> m_timer; /**< Qt timer for continuous updates */
+    gloperate::ChronoTimer m_time;  /**< Time measurement */
 };
 
 } // namespace gloperate_qt

--- a/source/gloperate-qt/source/QtOpenGLWindow.cpp
+++ b/source/gloperate-qt/source/QtOpenGLWindow.cpp
@@ -14,8 +14,8 @@
 
 #include <globjects/globjects.h>
 
-#include <widgetzeug/make_unique.hpp>
 
+#include <gloperate/base/make_unique.hpp>
 #include <gloperate/painter/AbstractViewportCapability.h>
 #include <gloperate/painter/AbstractInputCapability.h>
 #include <gloperate/resources/ResourceManager.h>
@@ -23,8 +23,6 @@
 
 #include <gloperate-qt/QtEventTransformer.h>
 
-
-using widgetzeug::make_unique;
 
 using namespace gloperate;
 namespace gloperate_qt

--- a/source/gloperate-qt/source/QtOpenGLWindow.cpp
+++ b/source/gloperate-qt/source/QtOpenGLWindow.cpp
@@ -192,8 +192,8 @@ void QtOpenGLWindow::mouseMoveEvent(QMouseEvent * event)
     {
         // Propagate event
         m_painter->getCapability<gloperate::AbstractInputCapability>()->onMouseMove(
-            event->x(),
-            event->y()
+            event->x() * devicePixelRatio(),
+            event->y() * devicePixelRatio()
         );
     }
 }
@@ -205,8 +205,8 @@ void QtOpenGLWindow::mousePressEvent(QMouseEvent * event)
     {
         // Propagate event
         m_painter->getCapability<gloperate::AbstractInputCapability>()->onMousePress(
-            event->x(),
-            event->y(),
+            event->x() * devicePixelRatio(),
+            event->y() * devicePixelRatio(),
             QtEventTransformer::fromQtMouseButton(event->button())
         );
     }
@@ -219,8 +219,8 @@ void QtOpenGLWindow::mouseReleaseEvent(QMouseEvent * event)
     {
         // Propagate event
         m_painter->getCapability<gloperate::AbstractInputCapability>()->onMouseRelease(
-            event->x(),
-            event->y(),
+            event->x() * devicePixelRatio(),
+            event->y() * devicePixelRatio(),
             QtEventTransformer::fromQtMouseButton(event->button())
         );
     }
@@ -233,8 +233,8 @@ void QtOpenGLWindow::mouseDoubleClickEvent(QMouseEvent * event)
     {
         // Propagate event
         m_painter->getCapability<gloperate::AbstractInputCapability>()->onMouseDoubleClick(
-            event->x(),
-            event->y(),
+            event->x() * devicePixelRatio(),
+            event->y() * devicePixelRatio(),
             QtEventTransformer::fromQtMouseButton(event->button())
         );
     }

--- a/source/gloperate-qt/source/QtOpenGLWindow.cpp
+++ b/source/gloperate-qt/source/QtOpenGLWindow.cpp
@@ -14,6 +14,8 @@
 
 #include <globjects/globjects.h>
 
+#include <widgetzeug/make_unique.hpp>
+
 #include <gloperate/painter/AbstractViewportCapability.h>
 #include <gloperate/painter/AbstractInputCapability.h>
 #include <gloperate/resources/ResourceManager.h>
@@ -21,6 +23,8 @@
 
 #include <gloperate-qt/QtEventTransformer.h>
 
+
+using widgetzeug::make_unique;
 
 using namespace gloperate;
 namespace gloperate_qt
@@ -31,10 +35,9 @@ namespace gloperate_qt
 *    Constructor
 */
 QtOpenGLWindow::QtOpenGLWindow(gloperate::ResourceManager & resourceManager)
-: QtOpenGLWindowBase()
-, m_resourceManager(resourceManager)
-, m_painter(nullptr)
-, m_timePropagator(nullptr)
+:   m_resourceManager(resourceManager)
+,   m_painter(nullptr)
+,   m_timePropagator(nullptr)
 {
 }
 
@@ -43,10 +46,10 @@ QtOpenGLWindow::QtOpenGLWindow(gloperate::ResourceManager & resourceManager)
 *    Constructor
 */
 QtOpenGLWindow::QtOpenGLWindow(gloperate::ResourceManager & resourceManager, const QSurfaceFormat & format)
-: QtOpenGLWindowBase(format)
-, m_resourceManager(resourceManager)
-, m_painter(nullptr)
-, m_timePropagator(nullptr)
+:   QtOpenGLWindowBase(format)
+,   m_resourceManager(resourceManager)
+,   m_painter(nullptr)
+,   m_timePropagator(nullptr)
 {
 }
 
@@ -77,18 +80,16 @@ void QtOpenGLWindow::setPainter(Painter * painter)
     m_painter = painter;
 
     // Destroy old time propagator
-    m_timePropagator.reset(nullptr);
+    m_timePropagator = nullptr;
 
     if (!m_painter)
-    {
         return;
-    }
+    
+    m_timePropagator = make_unique<TimePropagator>(this);
 
     // Check for virtual time capability
-    if (m_painter->supports<gloperate::AbstractVirtualTimeCapability>()) {
-        // Create a time propagator that updates the virtual time
-        m_timePropagator.reset(new TimePropagator(this, m_painter->getCapability<gloperate::AbstractVirtualTimeCapability>()));
-    }
+    if (m_painter->supports<AbstractVirtualTimeCapability>())
+        m_timePropagator->setCapability(m_painter->getCapability<AbstractVirtualTimeCapability>());
 
     m_initialized = false;
 }

--- a/source/gloperate/CMakeLists.txt
+++ b/source/gloperate/CMakeLists.txt
@@ -147,6 +147,7 @@ set(api_includes
     ${include_path}/base/CyclicTime.h
     ${include_path}/base/ChronoTimer.h
     ${include_path}/base/AutoTimer.h
+    ${include_path}/base/make_unique.hpp
     
     ${include_path}/gloperate_api.h
     

--- a/source/gloperate/include/gloperate/base/make_unique.hpp
+++ b/source/gloperate/include/gloperate/base/make_unique.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+
+
+namespace gloperate
+{
+
+/** 
+ * Replacement for C++14 implementation 
+ * as long as not all compilers support it. 
+ * Prefer over std::unique_ptr<Type>{new Type}
+ * \see http://herbsutter.com/gotw/_102/
+ */
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+} // namespace gloperate

--- a/source/gloperate/include/gloperate/painter/Painter.h
+++ b/source/gloperate/include/gloperate/painter/Painter.h
@@ -114,14 +114,14 @@ protected:
     *    Capability
     *
     *  @remarks
-    *    The painter takes ownership of the capability.
+    *    The painter does not take ownership of the capability.
     */
     void addCapability(AbstractCapability * capability);
 
 
 protected:
     ResourceManager                  & m_resourceManager; /**< Resource manager, e.g., to load and save textures */
-    std::vector<AbstractCapability*>   m_capabilities;    /**< List of supported capabilities */
+    std::vector<AbstractCapability *>  m_capabilities;    /**< List of supported capabilities */
 
 };
 

--- a/source/gloperate/include/gloperate/painter/Painter.h
+++ b/source/gloperate/include/gloperate/painter/Painter.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-
+#include <memory>
 #include <vector>
 
 #include <reflectionzeug/Object.h>
@@ -114,14 +114,17 @@ protected:
     *    Capability
     *
     *  @remarks
-    *    The painter does not take ownership of the capability.
+    *    The painter takes ownership of the capability.
     */
-    void addCapability(AbstractCapability * capability);
+    AbstractCapability * addCapability(std::unique_ptr<AbstractCapability> capability);
+    
+    template <typename Capability>
+    Capability * addCapability(std::unique_ptr<Capability> capability);
 
 
 protected:
-    ResourceManager                  & m_resourceManager; /**< Resource manager, e.g., to load and save textures */
-    std::vector<AbstractCapability *>  m_capabilities;    /**< List of supported capabilities */
+    ResourceManager & m_resourceManager; /**< Resource manager, e.g., to load and save textures */
+    std::vector<std::unique_ptr<AbstractCapability>>  m_capabilities; /**< List of supported capabilities */
 
 };
 

--- a/source/gloperate/include/gloperate/painter/Painter.hpp
+++ b/source/gloperate/include/gloperate/painter/Painter.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <gloperate/painter/Painter.h>
+
 
 namespace gloperate
 {
@@ -15,16 +17,24 @@ bool Painter::supports() const
 template <typename Capability>
 Capability * Painter::getCapability() const
 {
-    for (AbstractCapability * capability : m_capabilities)
+    for (auto & capability : m_capabilities)
     {
-        Capability * castCapability = dynamic_cast<Capability*>(capability);
+        Capability * castCapability = dynamic_cast<Capability *>(capability.get());
 
         if (castCapability != nullptr)
         {
             return castCapability;
         }
     }
+
     return nullptr;
+}
+
+template <typename Capability>
+Capability * Painter::addCapability(std::unique_ptr<Capability> capability)
+{
+    auto abstractCapability = std::unique_ptr<AbstractCapability>{std::move(capability)};
+    return static_cast<Capability *>(addCapability(std::move(abstractCapability)));
 }
 
 

--- a/source/gloperate/include/gloperate/pipeline/AbstractData.h
+++ b/source/gloperate/include/gloperate/pipeline/AbstractData.h
@@ -40,10 +40,11 @@ public:
     virtual std::string type() const = 0;
 
 public:
+    signalzeug::Signal<> invalidated;
+
+protected:
     AbstractStage * m_owner;
     std::string m_name;
-
-    signalzeug::Signal<> invalidated;
 
     void setOwner(AbstractStage * owner);
 };

--- a/source/gloperate/include/gloperate/pipeline/AbstractPipeline.h
+++ b/source/gloperate/include/gloperate/pipeline/AbstractPipeline.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <vector>
-#include <string>
+#include <memory>
 #include <set>
+#include <string>
+#include <vector>
 
 #include <gloperate/gloperate_api.h>
+
 
 namespace gloperate
 {
@@ -34,7 +36,7 @@ public:
 
     virtual void execute();
 
-    virtual void addStage(AbstractStage * stage);
+    virtual void addStage(std::unique_ptr<AbstractStage> stage);
 
     void addParameter(AbstractData * parameter);
     void addParameter(const std::string & name, AbstractData * parameter);
@@ -45,11 +47,11 @@ public:
     void shareData(const AbstractData* data);
     void shareDataFrom(const AbstractInputSlot& slot);
 
-    std::vector<AbstractInputSlot*> allInputs() const;
-    std::vector<AbstractData*> allOutputs() const;
+    std::vector<AbstractInputSlot *> allInputs() const;
+    std::vector<AbstractData *> allOutputs() const;
 
     AbstractData * findParameter(const std::string & name) const;
-    std::vector<AbstractData*> findOutputs(const std::string & name) const;
+    std::vector<AbstractData *> findOutputs(const std::string & name) const;
 
     template <typename T>
     Data<T> * getParameter(const std::string & name) const;
@@ -61,32 +63,32 @@ public:
     template <typename T>
     Data<T> * getOutput() const;
 
-    template<typename T, typename... Args>
-    void addStages(T stage, Args... pipeline);
+    template<typename... Args>
+    void addStages(std::unique_ptr<AbstractStage>, Args... pipeline);
 
-    const std::vector<AbstractStage*> & stages() const;
-    const std::vector<AbstractData*> & parameters() const;
+    std::vector<AbstractStage *> stages() const;
+    const std::vector<AbstractData *> & parameters() const;
 
-    std::set<AbstractData*> unusedParameters();
+    std::set<AbstractData *> unusedParameters();
 
 protected: 
-    void sortDependencies();
+    bool sortDependencies();
     void addStages();
-    void initializeStages();
+    bool initializeStages();
 
-    void tsort(std::vector<AbstractStage*> & stages);
+    static bool tsort(std::vector<std::unique_ptr<AbstractStage>> & stages);
 
 protected:
     bool m_initialized;
     std::string m_name;
-    std::vector<AbstractStage*> m_stages;
-    std::vector<AbstractData*> m_parameters;
-    std::vector<AbstractData*> m_constantParameters;
-    std::vector<const AbstractData*> m_sharedData;
+    std::vector<std::unique_ptr<AbstractStage>> m_stages;
+    std::vector<std::unique_ptr<AbstractData>> m_constantParameters;
+    std::vector<AbstractData *> m_parameters;
+    std::vector<const AbstractData *> m_sharedData;
     bool m_dependenciesSorted;
 
 private:
-    AbstractPipeline(const AbstractPipeline&) = delete;
+    AbstractPipeline(const AbstractPipeline &) = delete;
 };
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/AbstractPipeline.hpp
+++ b/source/gloperate/include/gloperate/pipeline/AbstractPipeline.hpp
@@ -2,6 +2,8 @@
 
 #include <gloperate/base/collection.hpp>
 
+#include <gloperate/base/make_unique.hpp>
+
 #include <gloperate/pipeline/AbstractPipeline.h>
 #include <gloperate/pipeline/AbstractData.h>
 #include <gloperate/pipeline/Data.h>
@@ -10,41 +12,41 @@
 namespace gloperate
 {
 
-template<typename T, typename... Args>
-void AbstractPipeline::addStages(T stage, Args... pipeline)
+template<typename... Args>
+void AbstractPipeline::addStages(std::unique_ptr<AbstractStage> stage, Args... pipeline)
 {
-    addStage(stage);
-    addStages(pipeline...);
+    addStage(std::move(stage));
+    addStages(std::forward<Args>(pipeline)...);
 }
 
 template <typename T>
 Data<T> * AbstractPipeline::addConstantParameter(const T & value)
 {
-    auto constant = new Data<T>(value);
+    auto constant = make_unique<Data<T>>(value);
 
-    m_constantParameters.push_back(constant);
+    m_constantParameters.push_back(std::move(constant));
 
-    return constant;
+    return constant.get();
 }
 
 template <typename T>
 Data<T> * AbstractPipeline::getParameter(const std::string & name) const
 {
-    return dynamic_cast<Data<T>*>(findParameter(name));
+    return dynamic_cast<Data<T> *>(findParameter(name));
 }
 
 template <typename T>
 Data<T> * AbstractPipeline::getParameter() const
 {
-    return dynamic_cast<Data<T>*>(collection::detect(m_parameters, [](AbstractData * parameter) { return dynamic_cast<Data<T>*>(parameter) != nullptr; }, nullptr));
+    return dynamic_cast<Data<T> *>(collection::detect(m_parameters, [](AbstractData * parameter) { return dynamic_cast<Data<T> *>(parameter) != nullptr; }, nullptr));
 }
 
 template <typename T>
 Data<T> * AbstractPipeline::getOutput(const std::string & name) const
 {
-    for (AbstractData* output : findOutputs(name))
+    for (AbstractData * output : findOutputs(name))
     {
-        Data<T>* data = dynamic_cast<Data<T>*>(output);
+        Data<T>* data = dynamic_cast<Data<T> *>(output);
         if (data)
         {
             return data;
@@ -57,7 +59,7 @@ Data<T> * AbstractPipeline::getOutput(const std::string & name) const
 template <typename T>
 Data<T> * AbstractPipeline::getOutput() const
 {
-    return dynamic_cast<Data<T>*>(collection::detect(allOutputs(), [](AbstractData * data) { return dynamic_cast<Data<T>*>(data) != nullptr; }, nullptr));
+    return dynamic_cast<Data<T> *>(collection::detect(allOutputs(), [](AbstractData * data) { return dynamic_cast<Data<T> *>(data) != nullptr; }, nullptr));
 }
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/Data.h
+++ b/source/gloperate/include/gloperate/pipeline/Data.h
@@ -32,7 +32,8 @@ public:
 
     void setData(const T & value);
 
-    virtual std::string type() const override { return typeid(T).name(); }
+    virtual std::string type() const override;
+    
 protected:
     T m_data;
 };

--- a/source/gloperate/include/gloperate/pipeline/Data.hpp
+++ b/source/gloperate/include/gloperate/pipeline/Data.hpp
@@ -67,7 +67,7 @@ template <typename T>
 const T & Data<T>::operator=(const T & value)
 {
     m_data = value;
-    invalidated();
+    invalidate();
 
     return value;
 }
@@ -76,7 +76,13 @@ template <typename T>
 void Data<T>::setData(const T & value)
 {
     m_data = value;
-    invalidated();
+    invalidate();
+}
+
+template <typename T>
+std::string Data<T>::type() const 
+{
+    return typeid(T).name(); 
 }
     
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/InputSlot.h
+++ b/source/gloperate/include/gloperate/pipeline/InputSlot.h
@@ -11,8 +11,10 @@
 namespace gloperate 
 {
 
-void GLOPERATE_API printIncompatibleMessage(const AbstractInputSlot* slot, const std::string& typeName,
-                              const AbstractData & data);
+void GLOPERATE_API printIncompatibleMessage(
+    const AbstractInputSlot * slot, 
+    const std::string & typeName,
+    const AbstractData & data);
 
 template <typename T>
 class InputSlot : public AbstractInputSlot
@@ -30,21 +32,20 @@ public:
 
     template <typename U>
     const Data<U> & operator=(const Data<U> & data);
+
     template <typename U>
     InputSlot<T> & operator=(InputSlot<U> & slot);
 
     virtual const AbstractData * connectedData() const override;
 
 protected:
-    const Data<T>* m_data;
+    const Data<T> * m_data;
     signalzeug::ScopedConnection m_connection;
 
     static const T s_defaultValue;
 
     template <typename U>
     void connect(const Data<U> & data);
-
-private:
 };
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/InputSlot.hpp
+++ b/source/gloperate/include/gloperate/pipeline/InputSlot.hpp
@@ -45,7 +45,7 @@ const T * InputSlot<T>::operator->() const
 template <typename T>
 bool InputSlot<T>::connectTo(const AbstractData & data)
 {
-    const Data<T> * data_ptr = dynamic_cast<const Data<T>*>(&data);
+    const Data<T> * data_ptr = dynamic_cast<const Data<T> *>(&data);
     
     if (!data_ptr)
     {
@@ -61,7 +61,7 @@ bool InputSlot<T>::connectTo(const AbstractData & data)
 template <typename T>
 bool InputSlot<T>::matchType(const AbstractData & data)
 {
-    const Data<T> * data_ptr = dynamic_cast<const Data<T>*>(&data);
+    const Data<T> * data_ptr = dynamic_cast<const Data<T> *>(&data);
 
     return data_ptr != nullptr;
 }
@@ -96,7 +96,7 @@ void InputSlot<T>::connect(const Data<U> & data)
 
     static_assert(std::is_same<T, U>::value || (std::is_pointer<T>::value && std::is_pointer<U>::value && std::is_base_of<Tp, Up>::value), "Types incompatible");
 
-    m_data = reinterpret_cast<const Data<T>*>(&data);
+    m_data = reinterpret_cast<const Data<T> *>(&data);
     m_connection = data.invalidated.connect([this]() { this->changed(); });
     connectionChanged();
     changed();

--- a/source/gloperate/include/gloperate/pipeline/PipelinePainter.h
+++ b/source/gloperate/include/gloperate/pipeline/PipelinePainter.h
@@ -19,24 +19,25 @@ class Data;
 class GLOPERATE_API PipelinePainter : public gloperate::Painter
 {
 public:
-    PipelinePainter(gloperate::ResourceManager & resourceManager, AbstractPipeline & pipeline, const std::string & name = "painter");
-    virtual ~PipelinePainter();
+    PipelinePainter(
+        gloperate::ResourceManager & resourceManager, 
+        AbstractPipeline & pipeline, 
+        const std::string & name = "painter");
 
     virtual void onInitialize() override;
     virtual void onPaint() override;
 
 protected:
-    AbstractPipeline & m_pipeline;
-    std::unordered_map<gloperate::AbstractData *, reflectionzeug::AbstractProperty *> m_dataToPropertyMap;
-
     reflectionzeug::AbstractProperty * propertyFor(gloperate::AbstractData * parameter) const;
     reflectionzeug::AbstractProperty * property(const std::string & name) const;
     template <typename T>
     reflectionzeug::Property<T> * getProperty(const std::string & name) const;
     template <typename T>
     reflectionzeug::Property<T> * createProperty(const std::string & name, gloperate::Data<T> & data);
-    template <typename T, typename K, typename V, typename... Args>
-    reflectionzeug::Property<T> * createProperty(const std::string & name, gloperate::Data<T> & data, const K & key, const V & value, Args&&... args);
+    
+protected:
+    AbstractPipeline & m_pipeline;
+    std::unordered_map<gloperate::AbstractData *, reflectionzeug::AbstractProperty *> m_dataToPropertyMap;
 };
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/pipeline/PipelinePainter.hpp
+++ b/source/gloperate/include/gloperate/pipeline/PipelinePainter.hpp
@@ -8,28 +8,17 @@ namespace gloperate
 template <typename T>
 reflectionzeug::Property<T> * PipelinePainter::getProperty(const std::string & name) const
 {
-    return dynamic_cast<reflectionzeug::Property<T>*>(property(name));
+    return dynamic_cast<reflectionzeug::Property<T> *>(property(name));
 }
 
 template <typename T>
 reflectionzeug::Property<T> * PipelinePainter::createProperty(const std::string & name, gloperate::Data<T> & data)
 {
     auto property = new reflectionzeug::Property<T>(name,
-       [& data]() { return data.data(); },
-       [& data](const T & value) { data.setData(value); }
-    );
+        [&data]() { return data.data(); },
+        [&data](const T & value) { data.setData(value); });
 
     m_dataToPropertyMap[std::addressof(data)] = property;
-
-    return property;
-}
-
-template <typename T, typename K, typename V, typename... Args>
-reflectionzeug::Property<T> * PipelinePainter::createProperty(const std::string & name, gloperate::Data<T> & data, const K & key, const V & value, Args&&... args)
-{
-    auto property = createProperty(name, data, std::forward<Args>(args)...);
-
-    property->setOption(key, value);
 
     return property;
 }

--- a/source/gloperate/source/painter/Painter.cpp
+++ b/source/gloperate/source/painter/Painter.cpp
@@ -7,18 +7,12 @@ namespace gloperate
 
 
 Painter::Painter(ResourceManager & resourceManager, const std::string & name)
-: Object(name)
-, m_resourceManager(resourceManager)
+:   Object(name)
+,   m_resourceManager(resourceManager)
 {
 }
 
-Painter::~Painter()
-{
-    // Destroy capabilities
-    for (AbstractCapability * capability : m_capabilities) {
-        delete capability;
-    }
-}
+Painter::~Painter() = default;
 
 void Painter::initialize()
 {

--- a/source/gloperate/source/painter/Painter.cpp
+++ b/source/gloperate/source/painter/Painter.cpp
@@ -24,9 +24,10 @@ void Painter::paint()
     onPaint();
 }
 
-void Painter::addCapability(AbstractCapability * capability)
+AbstractCapability * Painter::addCapability(std::unique_ptr<AbstractCapability> capability)
 {
-    m_capabilities.push_back(capability);
+    m_capabilities.push_back(std::move(capability));
+    return m_capabilities.back().get();
 }
 
 

--- a/source/gloperate/source/pipeline/InputSlot.cpp
+++ b/source/gloperate/source/pipeline/InputSlot.cpp
@@ -6,8 +6,11 @@
 namespace gloperate 
 {
 
-void printIncompatibleMessage(const AbstractInputSlot* slot, const std::string& typeName,
-                              const AbstractData & data) {
+void printIncompatibleMessage(
+    const AbstractInputSlot * slot, 
+    const std::string & typeName,                          
+    const AbstractData & data) 
+{
     std::cout
         << "Trying to connect incompatible type "
         << data.qualifiedName() << " (" << data.type() << ")"

--- a/source/gloperate/source/pipeline/PipelinePainter.cpp
+++ b/source/gloperate/source/pipeline/PipelinePainter.cpp
@@ -6,13 +6,12 @@
 namespace gloperate
 {
 
-PipelinePainter::PipelinePainter(gloperate::ResourceManager & resourceManager, AbstractPipeline & pipeline, const std::string & name)
-: Painter(resourceManager, name)
-, m_pipeline(pipeline)
-{
-}
-
-PipelinePainter::~PipelinePainter()
+PipelinePainter::PipelinePainter(
+    gloperate::ResourceManager & resourceManager, 
+    AbstractPipeline & pipeline, 
+    const std::string & name)
+:   Painter(resourceManager, name)
+,   m_pipeline(pipeline)
 {
 }
 

--- a/source/gloperate/source/tools/CoordinateProvider.cpp
+++ b/source/gloperate/source/tools/CoordinateProvider.cpp
@@ -15,10 +15,10 @@ CoordinateProvider::CoordinateProvider(
     AbstractProjectionCapability * projectionCapability,
     AbstractViewportCapability * viewportCapability,
     AbstractTypedRenderTargetCapability * typedRenderTargetCapability)
-    :   m_cameraCapability(cameraCapability)
-    ,   m_projectionCapability(projectionCapability)
-    ,   m_viewportCapability(viewportCapability)
-    ,   m_typedRenderTargetCapability(typedRenderTargetCapability)
+:   m_cameraCapability(cameraCapability)
+,   m_projectionCapability(projectionCapability)
+,   m_viewportCapability(viewportCapability)
+,   m_typedRenderTargetCapability(typedRenderTargetCapability)
 {
 }
 

--- a/source/tests/gloperate-test/AbstractPipeline_test.cpp
+++ b/source/tests/gloperate-test/AbstractPipeline_test.cpp
@@ -1,0 +1,25 @@
+#include <gmock/gmock.h>
+
+#include <iostream>
+
+#include "TestPipeline.hpp"
+
+
+using namespace gloperate;
+
+class AbstractPipeline_test : public testing::Test
+{
+public:
+    AbstractPipeline_test()
+    {
+    }
+
+protected:
+};
+
+TEST_F(AbstractPipeline_test, PipelineIsSortable)
+{
+    TestPipeline pipeline;
+    pipeline.initialize();
+    ASSERT_TRUE(pipeline.isInitialized());
+}

--- a/source/tests/gloperate-test/AbstractStage_test.cpp
+++ b/source/tests/gloperate-test/AbstractStage_test.cpp
@@ -1,0 +1,44 @@
+#include <gmock/gmock.h>
+
+#include "DummyStage.hpp"
+
+
+using namespace gloperate;
+
+class AbstractStage_test : public testing::Test
+{
+public:
+    AbstractStage_test()
+    :   stage0{"stage0", {}, { "output0" }}
+    ,   stage1{"stage1", { "input0" }, { "output0" }}
+    ,   stage2{"stage2", { "input0" }, {}}
+    {
+        stage1.inputs["input0"] = stage0.outputs["output0"];
+        stage2.inputs["input0"] = stage1.outputs["output0"];
+    }
+
+protected:
+    DummyStage stage0;
+    DummyStage stage1;
+    DummyStage stage2;
+};
+
+TEST_F(AbstractStage_test, Stage1RequiresStage0NonRecursive)
+{
+    ASSERT_TRUE(stage1.requires(&stage0, false));
+}
+
+TEST_F(AbstractStage_test, Stage2RequiresStage1NonRecursive)
+{
+    ASSERT_TRUE(stage2.requires(&stage1, false));
+}
+
+TEST_F(AbstractStage_test, Stage2DoesntRequireStage0NonRecursive)
+{
+    ASSERT_FALSE(stage2.requires(&stage0, false));
+}
+
+TEST_F(AbstractStage_test, Stage2DoesntRequireStage0Recursive)
+{
+    ASSERT_TRUE(stage2.requires(&stage0, true));
+}

--- a/source/tests/gloperate-test/CMakeLists.txt
+++ b/source/tests/gloperate-test/CMakeLists.txt
@@ -1,9 +1,24 @@
+
 set(target gloperate-test)
 message(STATUS "Test ${target}")
+
+
+# External libraries
+
+find_package(OpenGL REQUIRED)
+find_package(GLM REQUIRED)
+find_package(glbinding REQUIRED)
+find_package(globjects REQUIRED)
+find_package(libzeug REQUIRED)
 
 # Includes
 
 include_directories(   
+    BEFORE
+    ${GLM_INCLUDE_DIR}
+    ${GLBINDING_INCLUDES}
+    ${GLOBJECTS_INCLUDES}
+    ${LIBZEUG_INCLUDES}
 )
 
 include_directories(
@@ -16,6 +31,10 @@ include_directories(
 set(libs
     ${GMOCK_LIBRARIES}
     ${GTEST_LIBRARIES}
+    ${OPENGL_LIBRARIES}
+    ${GLBINDING_LIBRARIES}
+    ${GLOBJECTS_LIBRARIES}
+    ${LIBZEUG_LIBRARIES}
     gloperate
 )
 
@@ -24,6 +43,9 @@ set(libs
 set(sources
     main.cpp
     dummy_test.cpp
+    AbstractPipeline_test.cpp
+    AbstractStage_test.cpp
+    DummyStage.hpp
 )
 
 # Build executable

--- a/source/tests/gloperate-test/DummyStage.hpp
+++ b/source/tests/gloperate-test/DummyStage.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <gloperate/pipeline/AbstractStage.h>
+#include <gloperate/pipeline/Data.h>
+#include <gloperate/pipeline/InputSlot.h>
+
+
+using namespace gloperate;
+
+class DummyStage : public AbstractStage
+{
+public:
+    DummyStage(
+        const std::string & name,
+        const std::vector<std::string> & inputNames,
+        const std::vector<std::string> & outputNames)
+    :   AbstractStage(name)
+    {
+        for (const auto & inputName : inputNames)
+        {
+            addInput(name + "_" + inputName, inputs[inputName]);
+        }
+
+        for (const auto & outputName : outputNames)
+        {
+            addOutput(name + "_" + outputName, outputs[outputName]);
+        }
+    }
+    
+    virtual void process() override
+    {
+    }
+
+    std::map<std::string, InputSlot<int>> inputs;
+    std::map<std::string, Data<int>> outputs;
+};

--- a/source/tests/gloperate-test/TestPipeline.hpp
+++ b/source/tests/gloperate-test/TestPipeline.hpp
@@ -1,0 +1,108 @@
+
+#pragma once
+
+#include <gloperate/base/make_unique.hpp>
+#include <gloperate/pipeline/AbstractPipeline.h>
+
+#include "DummyStage.hpp"
+
+
+using namespace gloperate;
+
+class TestPipeline : public AbstractPipeline
+{
+public:
+    TestPipeline()
+    {
+        auto stage0 = make_unique<DummyStage>("", std::vector<std::string>{}, std::vector<std::string>{"output0", "output1"});
+        auto stage1 = make_unique<DummyStage>("", std::vector<std::string>{"input0"}, std::vector<std::string>{"output0"});
+        auto stage2 = make_unique<DummyStage>("", std::vector<std::string>{"input0"}, std::vector<std::string>{"output0"});
+        auto stage3 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1"}, std::vector<std::string>{"output0"});
+        auto stage4 = make_unique<DummyStage>("", std::vector<std::string>{"input0"}, std::vector<std::string>{"output0"});
+        auto stage5 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1"}, std::vector<std::string>{"output0"});
+        auto stage6 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1"}, std::vector<std::string>{"output0"});
+        auto stage7 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1"}, std::vector<std::string>{"output0"});
+        auto stage8 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1", "input2"}, std::vector<std::string>{"output0"});
+        auto stage9 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1", "input2"}, std::vector<std::string>{"output0"});
+        auto stage10 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1", "input2"}, std::vector<std::string>{"output0"});
+        auto stage11 = make_unique<DummyStage>("", std::vector<std::string>{"input0"}, std::vector<std::string>{"output0"});
+        auto stage12 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1", "input2"}, std::vector<std::string>{"output0"});
+        auto stage13 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1", "input2", "input3", "input4"}, std::vector<std::string>{"output0"});
+        auto stage14 = make_unique<DummyStage>("", std::vector<std::string>{"input0"}, std::vector<std::string>{"output0", "output1", "output2", "output3", "output4"});
+        auto stage15 = make_unique<DummyStage>("", std::vector<std::string>{"input0", "input1", "input2", "input3", "input4", "input5"}, std::vector<std::string>{"output0"});
+        auto stage16 = make_unique<DummyStage>("", std::vector<std::string>{"input0"}, std::vector<std::string>{});
+
+        stage1->inputs.at("input0") = stage0->outputs.at("output0");
+
+        stage2->inputs.at("input0") = stage1->outputs.at("output0");
+
+        stage3->inputs.at("input0") = stage0->outputs.at("output0");
+        stage3->inputs.at("input1") = stage2->outputs.at("output0");
+
+        stage4->inputs.at("input0") = stage3->outputs.at("output0");
+
+        stage5->inputs.at("input0") = stage3->outputs.at("output0");
+        stage5->inputs.at("input1") = stage4->outputs.at("output0");
+
+        stage6->inputs.at("input0") = stage3->outputs.at("output0");
+        stage6->inputs.at("input1") = stage4->outputs.at("output0");
+
+        stage7->inputs.at("input0") = stage3->outputs.at("output0");
+        stage7->inputs.at("input0") = stage4->outputs.at("output0");
+
+        stage8->inputs.at("input0") = stage3->outputs.at("output0");
+        stage8->inputs.at("input1") = stage4->outputs.at("output0");
+        stage8->inputs.at("input2") = stage5->outputs.at("output0");
+
+        stage9->inputs.at("input0") = stage3->outputs.at("output0");
+        stage9->inputs.at("input1") = stage4->outputs.at("output0");
+        stage9->inputs.at("input2") = stage6->outputs.at("output0");
+
+        stage10->inputs.at("input0") = stage3->outputs.at("output0");
+        stage10->inputs.at("input1") = stage4->outputs.at("output0");
+        stage10->inputs.at("input2") = stage7->outputs.at("output0");
+
+        stage11->inputs.at("input0") = stage10->outputs.at("output0");
+
+        stage12->inputs.at("input0") = stage3->outputs.at("output0");
+        stage12->inputs.at("input1") = stage4->outputs.at("output0");
+        stage12->inputs.at("input2") = stage8->outputs.at("output0");
+
+        stage13->inputs.at("input0") = stage3->outputs.at("output0");
+        stage13->inputs.at("input1") = stage4->outputs.at("output0");
+        stage13->inputs.at("input2") = stage12->outputs.at("output0");
+        stage13->inputs.at("input3") = stage9->outputs.at("output0");
+        stage13->inputs.at("input4") = stage11->outputs.at("output0");
+
+        stage14->inputs.at("input0") = stage13->outputs.at("output0");
+
+        stage15->inputs.at("input0") = stage14->outputs.at("output0");
+        stage15->inputs.at("input1") = stage14->outputs.at("output1");
+        stage15->inputs.at("input2") = stage14->outputs.at("output2");
+        stage15->inputs.at("input3") = stage14->outputs.at("output3");
+        stage15->inputs.at("input4") = stage14->outputs.at("output4");
+        stage15->inputs.at("input5") = stage0->outputs.at("output1");
+
+        stage16->inputs.at("input0") = stage15->outputs.at("output0");
+
+        addStages(
+            std::move(stage0),
+            std::move(stage1),
+            std::move(stage2),
+            std::move(stage3),
+            std::move(stage4),
+            std::move(stage5),
+            std::move(stage6),
+            std::move(stage7),
+            std::move(stage8),
+            std::move(stage9),
+            std::move(stage10),
+            std::move(stage11),
+            std::move(stage12),
+            std::move(stage13),
+            std::move(stage14),
+            std::move(stage15),
+            std::move(stage16));
+    }
+
+};


### PR DESCRIPTION
Changes:
* remove the need to provide `AbstractVirtualTimeCapability` for continuous redraw
* painter takes ownership of capabilities through `std::unique_ptr<>`
* make `AbstractTypedRenderTargetCapability` optional
* Fix `QtViewerMapping` and `QtOpenGLWindow` (`devicePixelRatio()`)
* add make_unique.hpp
* Use `std::unique_ptr<>` in AbstractPipeline
* add a few tests
* remove variadic templated `PipelinePainter::createProperty`