### PR TITLE
Texture coordinates and texture files in Scene

### DIFF
--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
@@ -5,7 +5,6 @@
 #include <gloperate/resources/Loader.h>
 
 #include <gloperate-assimp/gloperate-assimp_api.h>
-#include <vector>
 
 
 struct aiMesh;

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
@@ -5,7 +5,6 @@
 #include <gloperate/resources/Loader.h>
 
 #include <gloperate-assimp/gloperate-assimp_api.h>
-#include <gloperate/primitives/Bitmap.h>
 #include <vector>
 
 

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
@@ -5,6 +5,8 @@
 #include <gloperate/resources/Loader.h>
 
 #include <gloperate-assimp/gloperate-assimp_api.h>
+#include <gloperate/primitives/Bitmap.h>
+#include <vector>
 
 
 struct aiMesh;

--- a/source/gloperate-assimp/source/AssimpSceneLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpSceneLoader.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <iostream>
 #include <string>
-#include <map>
 
 #include <glm/glm.hpp>
 

--- a/source/gloperate-assimp/source/AssimpSceneLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpSceneLoader.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <iostream>
 #include <string>
+#include <map>
 
 #include <glm/glm.hpp>
 
@@ -131,11 +132,20 @@ Scene * AssimpSceneLoader::convertScene(const aiScene * scene) const
     Scene * sceneOut = new Scene;
 
     // Convert meshes from the scene
-    std::vector<PolygonalGeometry *> geometries;
     for (size_t i = 0; i < scene->mNumMeshes; ++i)
     {
         sceneOut->meshes().push_back(convertGeometry(scene->mMeshes[i]));
     }
+
+	for (size_t i = 0; i < scene->mNumMaterials; ++i)
+	{
+		aiString filename;
+		// only fetch texture with index 0
+		if (scene->mMaterials[i]->GetTexture(aiTextureType_DIFFUSE, 0, &filename) == aiReturn_SUCCESS)
+		{
+			sceneOut->materials()[i] = std::string(filename.C_Str());
+		}
+	}
 
     // Return scene
     return sceneOut;
@@ -178,9 +188,22 @@ PolygonalGeometry * AssimpSceneLoader::convertGeometry(const aiMesh * mesh) cons
         geometry->setNormals(std::move(normals));
     }
 
+	if (mesh->HasTextureCoords(0))
+	{
+		// Copy texture cooridinate array
+		std::vector<glm::vec3> textureCoordinates;
+		for (size_t i = 0; i < mesh->mNumVertices; ++i)
+		{
+			const auto & textureCoordinate = mesh->mTextureCoords[0][i];
+			textureCoordinates.push_back({ textureCoordinate.x, textureCoordinate.y, textureCoordinate.z });
+		}
+		geometry->setTextureCoordinates(std::move(textureCoordinates));
+	}
+
+	geometry->setMaterialIndex(mesh->mMaterialIndex);
+
     // Return geometry
     return geometry;
 }
-
 
 } // namespace gloperate_assimp

--- a/source/gloperate/include/gloperate/primitives/PolygonalDrawable.h
+++ b/source/gloperate/include/gloperate/primitives/PolygonalDrawable.h
@@ -73,11 +73,12 @@ public:
 
 
 protected:
-    globjects::ref_ptr<globjects::VertexArray> m_vao;       /**< Vertex array object */
-    globjects::ref_ptr<globjects::Buffer>      m_indices;   /**< Index buffer */
-    globjects::ref_ptr<globjects::Buffer>      m_vertices;  /**< Vertex buffer */
-    globjects::ref_ptr<globjects::Buffer>      m_normals;   /**< Normal buffer (may be empty) */
-    gl::GLsizei                                m_size;      /**< Number of elements (m_indices) */
+    globjects::ref_ptr<globjects::VertexArray> m_vao;                 /**< Vertex array object */
+    globjects::ref_ptr<globjects::Buffer>      m_indices;             /**< Index buffer */
+    globjects::ref_ptr<globjects::Buffer>      m_vertices;            /**< Vertex buffer */
+    globjects::ref_ptr<globjects::Buffer>      m_normals;             /**< Normal buffer (may be empty) */
+	globjects::ref_ptr<globjects::Buffer>      m_textureCoordinates;  /**< Texture coordinate buffer (may be empty) */
+    gl::GLsizei                                m_size;                /**< Number of elements (m_indices) */
 };
 
 

--- a/source/gloperate/include/gloperate/primitives/PolygonalDrawable.h
+++ b/source/gloperate/include/gloperate/primitives/PolygonalDrawable.h
@@ -77,7 +77,7 @@ protected:
     globjects::ref_ptr<globjects::Buffer>      m_indices;             /**< Index buffer */
     globjects::ref_ptr<globjects::Buffer>      m_vertices;            /**< Vertex buffer */
     globjects::ref_ptr<globjects::Buffer>      m_normals;             /**< Normal buffer (may be empty) */
-	globjects::ref_ptr<globjects::Buffer>      m_textureCoordinates;  /**< Texture coordinate buffer (may be empty) */
+    globjects::ref_ptr<globjects::Buffer>      m_textureCoordinates;  /**< Texture coordinate buffer (may be empty) */
     gl::GLsizei                                m_size;                /**< Number of elements (m_indices) */
 };
 

--- a/source/gloperate/include/gloperate/primitives/PolygonalGeometry.h
+++ b/source/gloperate/include/gloperate/primitives/PolygonalGeometry.h
@@ -178,7 +178,7 @@ public:
 	*  @param[in] materialIndex
 	*    Material index
 	*/
-	void setMaterialIndex(const unsigned int materialIndex);
+	void setMaterialIndex(unsigned int materialIndex);
 
 protected:
     std::vector<unsigned int> m_indices;              /**< Index array */

--- a/source/gloperate/include/gloperate/primitives/PolygonalGeometry.h
+++ b/source/gloperate/include/gloperate/primitives/PolygonalGeometry.h
@@ -126,22 +126,66 @@ public:
     */
     void setNormals(std::vector<glm::vec3> && normals);
 
+	/**
+	*  @brief
+	*    Check if mesh contains texture coordinates
+	*
+	*  @return
+	*    'true' if the mesh contains texture coordinates, otherwise 'false'
+	*/
 	bool hasTextureCoordinates() const;
+
+	/**
+	*  @brief
+	*    Get texture coordinate array
+	*
+	*  @return
+	*    Texture coordinate array
+	*/
 	const std::vector<glm::vec3> & textureCoordinates() const;
 
+	/**
+	*  @brief
+	*    Set texture coordinates
+	*
+	*  @param[in] textureCoordinates
+	*    Texture coordinate array
+	*/
 	void setTextureCoordinates(const std::vector<glm::vec3> & textureCoordinates);
+
+	/**
+	*  @brief
+	*    Set texture coordinates
+	*
+	*  @param[in] textureCoordinates
+	*    Texture coordinate array
+	*/
 	void setTextureCoordinates(std::vector<glm::vec3> && textureCoordinates);
 
+	/**
+	*  @brief
+	*    Get material index
+	*
+	*  @return
+	*    Material index
+	*/
 	unsigned int materialIndex() const;
 
+	/**
+	*  @brief
+	*    Set material index
+	*
+	*  @param[in] materialIndex
+	*    Material index
+	*/
 	void setMaterialIndex(const unsigned int materialIndex);
 
 protected:
-    std::vector<unsigned int> m_indices;    /**< Index array */
-    std::vector<glm::vec3>    m_vertices;   /**< Vertex array */
-    std::vector<glm::vec3>    m_normals;    /**< Normal array */
-	std::vector<glm::vec3>    m_textureCoordinates;
-	unsigned int              m_materialIndex;
+    std::vector<unsigned int> m_indices;              /**< Index array */
+    std::vector<glm::vec3>    m_vertices;             /**< Vertex array */
+    std::vector<glm::vec3>    m_normals;              /**< Normal array */
+	std::vector<glm::vec3>    m_textureCoordinates;   /**< Texture coordinate array */
+	unsigned int              m_materialIndex;        /**< Material index */
 };
 
 

--- a/source/gloperate/include/gloperate/primitives/PolygonalGeometry.h
+++ b/source/gloperate/include/gloperate/primitives/PolygonalGeometry.h
@@ -126,11 +126,22 @@ public:
     */
     void setNormals(std::vector<glm::vec3> && normals);
 
+	bool hasTextureCoordinates() const;
+	const std::vector<glm::vec3> & textureCoordinates() const;
+
+	void setTextureCoordinates(const std::vector<glm::vec3> & textureCoordinates);
+	void setTextureCoordinates(std::vector<glm::vec3> && textureCoordinates);
+
+	unsigned int materialIndex() const;
+
+	void setMaterialIndex(const unsigned int materialIndex);
 
 protected:
     std::vector<unsigned int> m_indices;    /**< Index array */
     std::vector<glm::vec3>    m_vertices;   /**< Vertex array */
     std::vector<glm::vec3>    m_normals;    /**< Normal array */
+	std::vector<glm::vec3>    m_textureCoordinates;
+	unsigned int              m_materialIndex;
 };
 
 

--- a/source/gloperate/include/gloperate/primitives/Scene.h
+++ b/source/gloperate/include/gloperate/primitives/Scene.h
@@ -4,7 +4,6 @@
 
 #include <vector>
 #include <map>
-#include <string>
 
 #include <gloperate/gloperate_api.h>
 

--- a/source/gloperate/include/gloperate/primitives/Scene.h
+++ b/source/gloperate/include/gloperate/primitives/Scene.h
@@ -3,6 +3,8 @@
 
 
 #include <vector>
+#include <map>
+#include <string>
 
 #include <gloperate/gloperate_api.h>
 
@@ -56,9 +58,27 @@ public:
     */
     std::vector<PolygonalGeometry *> & meshes();
 
+	/**
+	*  @brief
+	*    Get materials by material id
+	*
+	*  @return
+	*    Map of materials
+	*/
+	const std::map<unsigned int, std::string> & materials() const;
+
+	/**
+	*  @brief
+	*    Get materials by material id
+	*
+	*  @return
+	*    Map of materials
+	*/
+	std::map<unsigned int, std::string> & materials();
 
 protected:
-    std::vector<PolygonalGeometry *> m_meshes;    /**< Mesh array */
+    std::vector<PolygonalGeometry *> m_meshes;        /**< Mesh array */
+	std::map<unsigned int, std::string> m_materials;  /**< Materials map */
 };
 
 

--- a/source/gloperate/include/gloperate/resources/ResourceManager.hpp
+++ b/source/gloperate/include/gloperate/resources/ResourceManager.hpp
@@ -18,6 +18,7 @@ T * ResourceManager::load(const std::string & filename, std::function<void(int, 
 {
     // Get file extension
     std::string ext = getFileExtension(filename);
+	transform(ext.begin(), ext.end(), ext.begin(), tolower);
 
     // Find suitable loader
     for (AbstractLoader * loader : m_loaders) {

--- a/source/gloperate/source/primitives/PolygonalDrawable.cpp
+++ b/source/gloperate/source/primitives/PolygonalDrawable.cpp
@@ -41,6 +41,13 @@ PolygonalDrawable::PolygonalDrawable(const PolygonalGeometry & geometry)
         m_normals->setData(geometry.normals(), GL_STATIC_DRAW);
     }
 
+	// Create and copy texture coordinate buffer
+	if (geometry.hasTextureCoordinates())
+	{
+		m_textureCoordinates = new globjects::Buffer;
+		m_textureCoordinates->setData(geometry.textureCoordinates(), GL_STATIC_DRAW);
+	}
+
     // Create vertex array object
     m_vao = new globjects::VertexArray;
     m_vao->bind();
@@ -61,6 +68,15 @@ PolygonalDrawable::PolygonalDrawable(const PolygonalGeometry & geometry)
         vertexBinding->setFormat(3, gl::GL_FLOAT, GL_TRUE);
         m_vao->enable(1);
     }
+
+	if (geometry.hasTextureCoordinates())
+	{
+		auto vertexBinding = m_vao->binding(2);
+		vertexBinding->setAttribute(2);
+		vertexBinding->setBuffer(m_textureCoordinates, 0, sizeof(glm::vec3));
+		vertexBinding->setFormat(3, gl::GL_FLOAT);
+		m_vao->enable(2);
+	}	
 
     m_vao->unbind();
 }

--- a/source/gloperate/source/primitives/PolygonalGeometry.cpp
+++ b/source/gloperate/source/primitives/PolygonalGeometry.cpp
@@ -66,5 +66,34 @@ void PolygonalGeometry::setNormals(std::vector<glm::vec3> && normals)
     m_normals = std::move(normals);
 }
 
+bool PolygonalGeometry::hasTextureCoordinates() const
+{
+	return !m_textureCoordinates.empty();
+}
+
+const std::vector<glm::vec3> & PolygonalGeometry::textureCoordinates() const
+{
+	return m_textureCoordinates;
+}
+
+void PolygonalGeometry::setTextureCoordinates(const std::vector<glm::vec3> & textureCoordinates)
+{
+	m_textureCoordinates = textureCoordinates;
+}
+
+void PolygonalGeometry::setTextureCoordinates(std::vector<glm::vec3> && textureCoordinates)
+{
+	m_textureCoordinates = std::move(textureCoordinates);
+}
+
+unsigned PolygonalGeometry::materialIndex() const
+{
+	return m_materialIndex;
+}
+
+void PolygonalGeometry::setMaterialIndex(const unsigned materialIndex)
+{
+	m_materialIndex = materialIndex;
+}
 
 } // namespace gloperate

--- a/source/gloperate/source/primitives/PolygonalGeometry.cpp
+++ b/source/gloperate/source/primitives/PolygonalGeometry.cpp
@@ -91,7 +91,7 @@ unsigned PolygonalGeometry::materialIndex() const
 	return m_materialIndex;
 }
 
-void PolygonalGeometry::setMaterialIndex(const unsigned materialIndex)
+void PolygonalGeometry::setMaterialIndex(const unsigned int materialIndex)
 {
 	m_materialIndex = materialIndex;
 }

--- a/source/gloperate/source/primitives/Scene.cpp
+++ b/source/gloperate/source/primitives/Scene.cpp
@@ -32,5 +32,14 @@ std::vector<PolygonalGeometry *> & Scene::meshes()
     return m_meshes;
 }
 
+const std::map<unsigned, std::string>& Scene::materials() const
+{
+	return m_materials;
+}
+
+std::map<unsigned, std::string>& Scene::materials()
+{
+	return m_materials;
+}
 
 } // namespace gloperate


### PR DESCRIPTION
This extends Scene, PolygonalGeometry and PolygonalDrawable in order to hold material/texture Information. It also extends the assimp loader to populate the Scene with this information, if available.

**Limitations/possible enhancements:**

 - Only the first texture coordinate set is loaded
 - Only the first texture file name per material is loaded, and only the diffuse texture is considered
 - No texture parameters are loaded (e.g. if image mapping is repeat, mirror,...)
 - Only the filename of the material's texture is stored in the Scene - a Material primitive class could be useful for more advanced use cases
 - Management of Texture-Objects is not integrated with PolygonalDrawable yet

For a demo on how to load and bind the textures using QImage see the GeometryStage.cpp in the massivelighting branch of https://github.com/valentin-pinkau/glexamples

It would be great if other groups could build on top of this :wink: