### PR TITLE
Add mesh loader option

### DIFF
--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
@@ -43,7 +43,7 @@ public:
     virtual bool canLoad(const std::string & ext) const override;
     virtual std::vector<std::string> loadingTypes() const override;
     virtual std::string allLoadingTypes() const override;
-    virtual gloperate::PolygonalGeometry * load(const std::string & filename, std::function<void(int, int)> progress) const override;
+    virtual gloperate::PolygonalGeometry * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
 
 
 protected:

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
@@ -19,7 +19,8 @@ namespace gloperate
 namespace gloperate_assimp
 {
 
-enum MeshLoadOptions {
+enum class MeshLoadOptions : unsigned int
+{
     /**
     *  @brief
     *    use default options
@@ -31,6 +32,10 @@ enum MeshLoadOptions {
     */
     SmoothNormals   = 0x01
 };
+
+MeshLoadOptions operator&(MeshLoadOptions a, MeshLoadOptions b);
+MeshLoadOptions operator|(MeshLoadOptions a, MeshLoadOptions b);
+MeshLoadOptions operator^(MeshLoadOptions a, MeshLoadOptions b);
 
 /**
 *  @brief

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
@@ -20,7 +20,15 @@ namespace gloperate_assimp
 {
 
 enum MeshLoadOptions {
+    /**
+    *  @brief
+    *    use default options
+    */
     None            = 0x00,
+    /**
+    *  @brief
+    *    generate smooth normals
+    */
     SmoothNormals   = 0x01
 };
 
@@ -47,6 +55,21 @@ public:
     virtual bool canLoad(const std::string & ext) const override;
     virtual std::vector<std::string> loadingTypes() const override;
     virtual std::string allLoadingTypes() const override;
+    /**
+    *  @brief
+    *    Load mesh from file
+    *
+    *  @param[in] filename
+    *    File name
+    *  @param[in] options
+    *    Options for loading mesh (can be empty),
+    *    a Variant holding a value from the enum MeshLoadOptions 
+    *  @param[in] progress
+    *    Callback function that is invoked on progress (can be empty)
+    *
+    *  @return
+    *    Loaded resource (can be null)
+    */
     virtual gloperate::PolygonalGeometry * load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> progress) const override;
 
 

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
@@ -19,6 +19,10 @@ namespace gloperate
 namespace gloperate_assimp
 {
 
+enum MeshLoadOptions {
+    None            = 0x00,
+    SmoothNormals   = 0x01
+};
 
 /**
 *  @brief

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpMeshLoader.h
@@ -47,7 +47,7 @@ public:
     virtual bool canLoad(const std::string & ext) const override;
     virtual std::vector<std::string> loadingTypes() const override;
     virtual std::string allLoadingTypes() const override;
-    virtual gloperate::PolygonalGeometry * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
+    virtual gloperate::PolygonalGeometry * load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> progress) const override;
 
 
 protected:

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
@@ -44,7 +44,7 @@ public:
     virtual bool canLoad(const std::string & ext) const override;
     virtual std::vector<std::string> loadingTypes() const override;
     virtual std::string allLoadingTypes() const override;
-    virtual gloperate::Scene * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
+    virtual gloperate::Scene * load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> progress) const override;
 
 
 protected:

--- a/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
+++ b/source/gloperate-assimp/include/gloperate-assimp/AssimpSceneLoader.h
@@ -44,7 +44,7 @@ public:
     virtual bool canLoad(const std::string & ext) const override;
     virtual std::vector<std::string> loadingTypes() const override;
     virtual std::string allLoadingTypes() const override;
-    virtual gloperate::Scene * load(const std::string & filename, std::function<void(int, int)> progress) const override;
+    virtual gloperate::Scene * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
 
 
 protected:

--- a/source/gloperate-assimp/source/AssimpMeshLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpMeshLoader.cpp
@@ -23,6 +23,22 @@ using namespace gloperate;
 namespace gloperate_assimp
 {
 
+MeshLoadOptions operator&(MeshLoadOptions a, MeshLoadOptions b)
+{
+    return static_cast<MeshLoadOptions>(
+        static_cast<unsigned int>(a) & static_cast<unsigned int>(b));
+}
+MeshLoadOptions operator|(MeshLoadOptions a, MeshLoadOptions b)
+{
+    return static_cast<MeshLoadOptions>(
+        static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
+}
+MeshLoadOptions operator^(MeshLoadOptions a, MeshLoadOptions b)
+{
+    return static_cast<MeshLoadOptions>(
+        static_cast<unsigned int>(a) ^ static_cast<unsigned int>(b));
+}
+
 
 AssimpMeshLoader::AssimpMeshLoader()
 {
@@ -102,14 +118,15 @@ std::string AssimpMeshLoader::allLoadingTypes() const
 PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> /*progress*/) const
 {
     auto flags = options.value<MeshLoadOptions>(MeshLoadOptions::None);
-    auto normals = (flags & SmoothNormals) ? aiProcess_GenSmoothNormals : aiProcess_GenNormals;
+    bool smoothNormals = (flags & MeshLoadOptions::SmoothNormals) == MeshLoadOptions::SmoothNormals;
+    auto normalsFlag = smoothNormals ? aiProcess_GenSmoothNormals : aiProcess_GenNormals;
     // Import scene
     auto scene = aiImportFile(
         filename.c_str(),
         aiProcess_Triangulate           |
         aiProcess_JoinIdenticalVertices |
         aiProcess_SortByPType |
-        normals);
+        normalsFlag);
 
     // Check for errors
     if (!scene)

--- a/source/gloperate-assimp/source/AssimpMeshLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpMeshLoader.cpp
@@ -99,15 +99,17 @@ std::string AssimpMeshLoader::allLoadingTypes() const
     return string;
 }
 
-PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
+PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> /*progress*/) const
 {
+    auto map = options.value<std::map<std::string, bool>>();
+    auto normals = map["smoothNormals"] ? aiProcess_GenSmoothNormals : aiProcess_GenNormals;
     // Import scene
     auto scene = aiImportFile(
         filename.c_str(),
         aiProcess_Triangulate           |
         aiProcess_JoinIdenticalVertices |
         aiProcess_SortByPType |
-        aiProcess_GenNormals);
+        normals);
 
     // Check for errors
     if (!scene)

--- a/source/gloperate-assimp/source/AssimpMeshLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpMeshLoader.cpp
@@ -101,8 +101,8 @@ std::string AssimpMeshLoader::allLoadingTypes() const
 
 PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> /*progress*/) const
 {
-    auto map = options.value<std::map<std::string, bool>>();
-    auto normals = map["smoothNormals"] ? aiProcess_GenSmoothNormals : aiProcess_GenNormals;
+    auto flags = options.value<MeshLoadOptions>(MeshLoadOptions::None);
+    auto normals = (flags & SmoothNormals) ? aiProcess_GenSmoothNormals : aiProcess_GenNormals;
     // Import scene
     auto scene = aiImportFile(
         filename.c_str(),

--- a/source/gloperate-assimp/source/AssimpMeshLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpMeshLoader.cpp
@@ -99,7 +99,7 @@ std::string AssimpMeshLoader::allLoadingTypes() const
     return string;
 }
 
-PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> /*progress*/) const
+PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> /*progress*/) const
 {
     auto flags = options.value<MeshLoadOptions>(MeshLoadOptions::None);
     auto normals = (flags & SmoothNormals) ? aiProcess_GenSmoothNormals : aiProcess_GenNormals;

--- a/source/gloperate-assimp/source/AssimpMeshLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpMeshLoader.cpp
@@ -14,6 +14,8 @@
 
 #include <gloperate/primitives/PolygonalGeometry.h>
 
+#include <reflectionzeug/Variant.h>
+
 
 using namespace gloperate;
 
@@ -97,7 +99,7 @@ std::string AssimpMeshLoader::allLoadingTypes() const
     return string;
 }
 
-PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, std::function<void(int, int)> /*progress*/) const
+PolygonalGeometry * AssimpMeshLoader::load(const std::string & filename, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
 {
     // Import scene
     auto scene = aiImportFile(

--- a/source/gloperate-assimp/source/AssimpSceneLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpSceneLoader.cpp
@@ -15,6 +15,7 @@
 #include <gloperate/primitives/PolygonalGeometry.h>
 #include <gloperate/primitives/Scene.h>
 
+#include <reflectionzeug/Variant.h>
 
 using namespace gloperate;
 
@@ -98,7 +99,7 @@ std::string AssimpSceneLoader::allLoadingTypes() const
     return string;
 }
 
-Scene * AssimpSceneLoader::load(const std::string & filename, std::function<void(int, int)> /*progress*/) const
+Scene * AssimpSceneLoader::load(const std::string & filename, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
 {
     // Import scene
     auto assimpScene = aiImportFile(

--- a/source/gloperate-assimp/source/AssimpSceneLoader.cpp
+++ b/source/gloperate-assimp/source/AssimpSceneLoader.cpp
@@ -99,7 +99,7 @@ std::string AssimpSceneLoader::allLoadingTypes() const
     return string;
 }
 
-Scene * AssimpSceneLoader::load(const std::string & filename, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
+Scene * AssimpSceneLoader::load(const std::string & filename, const reflectionzeug::Variant &/*options*/, std::function<void(int, int)> /*progress*/) const
 {
     // Import scene
     auto assimpScene = aiImportFile(

--- a/source/gloperate-qt/include/gloperate-qt/QtTextureLoader.h
+++ b/source/gloperate-qt/include/gloperate-qt/QtTextureLoader.h
@@ -41,7 +41,7 @@ public:
     virtual std::string allLoadingTypes() const;
 
     // Virtual gloperate::Loader<globjects::Texture> functions
-    virtual globjects::Texture * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
+    virtual globjects::Texture * load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> progress) const override;
 
 
 protected:

--- a/source/gloperate-qt/include/gloperate-qt/QtTextureLoader.h
+++ b/source/gloperate-qt/include/gloperate-qt/QtTextureLoader.h
@@ -41,7 +41,7 @@ public:
     virtual std::string allLoadingTypes() const;
 
     // Virtual gloperate::Loader<globjects::Texture> functions
-    virtual globjects::Texture * load(const std::string & filename, std::function<void(int, int)> progress) const override;
+    virtual globjects::Texture * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
 
 
 protected:

--- a/source/gloperate-qt/source/QtTextureLoader.cpp
+++ b/source/gloperate-qt/source/QtTextureLoader.cpp
@@ -75,7 +75,7 @@ std::string QtTextureLoader::allLoadingTypes() const
     return allTypes;
 }
 
-globjects::Texture * QtTextureLoader::load(const std::string & filename, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
+globjects::Texture * QtTextureLoader::load(const std::string & filename, const reflectionzeug::Variant & /*options*/, std::function<void(int, int)> /*progress*/) const
 {
     // Load image
     QImage image;

--- a/source/gloperate-qt/source/QtTextureLoader.cpp
+++ b/source/gloperate-qt/source/QtTextureLoader.cpp
@@ -12,6 +12,8 @@
 
 #include <gloperate-qt/Converter.h>
 
+#include <reflectionzeug/Variant.h>
+
 
 namespace gloperate_qt
 {
@@ -73,7 +75,7 @@ std::string QtTextureLoader::allLoadingTypes() const
     return allTypes;
 }
 
-globjects::Texture * QtTextureLoader::load(const std::string & filename, std::function<void(int, int)> /*progress*/) const
+globjects::Texture * QtTextureLoader::load(const std::string & filename, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
 {
     // Load image
     QImage image;

--- a/source/gloperate/include/gloperate/resources/GlrawTextureLoader.h
+++ b/source/gloperate/include/gloperate/resources/GlrawTextureLoader.h
@@ -34,7 +34,7 @@ public:
     virtual std::string allLoadingTypes() const override;
 
     // Virtual gloperate::Loader<globjects::Texture> functions
-    virtual globjects::Texture * load(const std::string & filename, std::function<void(int, int)> progress) const override;
+    virtual globjects::Texture * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
 };
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/resources/GlrawTextureLoader.h
+++ b/source/gloperate/include/gloperate/resources/GlrawTextureLoader.h
@@ -34,7 +34,7 @@ public:
     virtual std::string allLoadingTypes() const override;
 
     // Virtual gloperate::Loader<globjects::Texture> functions
-    virtual globjects::Texture * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const override;
+    virtual globjects::Texture * load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> progress) const override;
 };
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/resources/Loader.h
+++ b/source/gloperate/include/gloperate/resources/Loader.h
@@ -38,6 +38,8 @@ public:
     *
     *  @param[in] filename
     *    File name
+    *  @param[in] options
+    *    Options for loading resource (can be empty)
     *  @param[in] progress
     *    Callback function that is invoked on progress (can be empty)
     *

--- a/source/gloperate/include/gloperate/resources/Loader.h
+++ b/source/gloperate/include/gloperate/resources/Loader.h
@@ -46,7 +46,7 @@ public:
     *  @return
     *    Loaded resource (can be null)
     */
-    virtual T * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const = 0;
+    virtual T * load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> progress) const = 0;
 };
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/resources/Loader.h
+++ b/source/gloperate/include/gloperate/resources/Loader.h
@@ -5,6 +5,9 @@
 
 #include <gloperate/resources/AbstractLoader.h>
 
+namespace reflectionzeug {
+    class Variant;
+}
 
 namespace gloperate
 {
@@ -41,7 +44,7 @@ public:
     *  @return
     *    Loaded resource (can be null)
     */
-    virtual T * load(const std::string & filename, std::function<void(int, int)> progress) const = 0;
+    virtual T * load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const = 0;
 };
 
 } // namespace gloperate

--- a/source/gloperate/include/gloperate/resources/ResourceManager.h
+++ b/source/gloperate/include/gloperate/resources/ResourceManager.h
@@ -8,6 +8,8 @@
 
 #include <gloperate/gloperate_api.h>
 
+#include <reflectionzeug/Variant.h>
+
 
 namespace globjects 
 {
@@ -82,6 +84,8 @@ public:
     *
     *  @param[in] filename
     *    File name
+    *  @param[in] options
+    *    Options for loading resource (can be empty)
     *  @param[in] progress
     *    Callback function that is invoked on progress (can be empty)
     *
@@ -89,7 +93,7 @@ public:
     *    Loaded resource (can be null)
     */
     template <typename T>
-    T * load(const std::string & filename, std::function<void(int, int)> progress = std::function<void(int, int)>() ) const;
+    T * load(const std::string & filename, reflectionzeug::Variant options = reflectionzeug::Variant(), std::function<void(int, int)> progress = std::function<void(int, int)>()) const;
 
     /**
     *  @brief

--- a/source/gloperate/include/gloperate/resources/ResourceManager.h
+++ b/source/gloperate/include/gloperate/resources/ResourceManager.h
@@ -85,7 +85,8 @@ public:
     *  @param[in] filename
     *    File name
     *  @param[in] options
-    *    Options for loading resource (can be empty)
+    *    Options for loading resource (can be empty),
+    *    see the specific loader for a description of the options
     *  @param[in] progress
     *    Callback function that is invoked on progress (can be empty)
     *

--- a/source/gloperate/include/gloperate/resources/ResourceManager.h
+++ b/source/gloperate/include/gloperate/resources/ResourceManager.h
@@ -93,7 +93,7 @@ public:
     *    Loaded resource (can be null)
     */
     template <typename T>
-    T * load(const std::string & filename, reflectionzeug::Variant options = reflectionzeug::Variant(), std::function<void(int, int)> progress = std::function<void(int, int)>()) const;
+    T * load(const std::string & filename, const reflectionzeug::Variant & options = reflectionzeug::Variant(), std::function<void(int, int)> progress = std::function<void(int, int)>()) const;
 
     /**
     *  @brief

--- a/source/gloperate/include/gloperate/resources/ResourceManager.hpp
+++ b/source/gloperate/include/gloperate/resources/ResourceManager.hpp
@@ -16,7 +16,7 @@ namespace gloperate
 *    Load resource from file
 */
 template <typename T>
-T * ResourceManager::load(const std::string & filename, std::function<void(int, int)> progress) const
+T * ResourceManager::load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const
 {
     // Get file extension
     std::string ext = getFileExtension(filename);
@@ -29,7 +29,7 @@ T * ResourceManager::load(const std::string & filename, std::function<void(int, 
             // Check if filetype is supported
             if (concreteLoader->canLoad(ext)) {
                 // Use loader
-                return concreteLoader->load(filename, progress);
+                return concreteLoader->load(filename, options, progress);
             }
         }
     }

--- a/source/gloperate/include/gloperate/resources/ResourceManager.hpp
+++ b/source/gloperate/include/gloperate/resources/ResourceManager.hpp
@@ -16,7 +16,7 @@ namespace gloperate
 *    Load resource from file
 */
 template <typename T>
-T * ResourceManager::load(const std::string & filename, reflectionzeug::Variant options, std::function<void(int, int)> progress) const
+T * ResourceManager::load(const std::string & filename, const reflectionzeug::Variant & options, std::function<void(int, int)> progress) const
 {
     // Get file extension
     std::string ext = getFileExtension(filename);

--- a/source/gloperate/source/resources/GlrawTextureLoader.cpp
+++ b/source/gloperate/source/resources/GlrawTextureLoader.cpp
@@ -1,4 +1,6 @@
 #include <gloperate/resources/GlrawTextureLoader.h>
+
+#include <reflectionzeug/Variant.h>
  
 
 namespace gloperate
@@ -40,7 +42,7 @@ std::string GlrawTextureLoader::allLoadingTypes() const
     return "*.glraw";
 }
 
-globjects::Texture * GlrawTextureLoader::load(const std::string & /*filename*/, std::function<void(int, int)> /*progress*/) const
+globjects::Texture * GlrawTextureLoader::load(const std::string & /*filename*/, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
 {
     // [TODO] Implement!
     return nullptr;

--- a/source/gloperate/source/resources/GlrawTextureLoader.cpp
+++ b/source/gloperate/source/resources/GlrawTextureLoader.cpp
@@ -42,7 +42,7 @@ std::string GlrawTextureLoader::allLoadingTypes() const
     return "*.glraw";
 }
 
-globjects::Texture * GlrawTextureLoader::load(const std::string & /*filename*/, reflectionzeug::Variant /*options*/, std::function<void(int, int)> /*progress*/) const
+globjects::Texture * GlrawTextureLoader::load(const std::string & /*filename*/, const reflectionzeug::Variant & /*options*/, std::function<void(int, int)> /*progress*/) const
 {
     // [TODO] Implement!
     return nullptr;


### PR DESCRIPTION
1. Add a parameter "options" to the load method of Loader and its subclasses as well as the ResourceManager. It takes the form of a Variant, so it can be adapted to all possible forms of options.
2. Using the above add the option to generate smooth normals to the AssimpMeshLoader.
